### PR TITLE
Pull repository from git, not release tarball

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -34,7 +34,7 @@ CONDARC
 mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
     pip mamba conda-build boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup
+    pip mamba conda-build boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,12 +5,14 @@ package:
   name: {{ name|lower }}
   version: {{ version }}
 
+# We check out the repository instead of pulling a tarball so that the
+# Git LFS references will be resolved.
 source:
-  url: https://github.com/sandialabs/tracktable-data/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 6d3c559cb99785d4623cc39701dde56f083d09d3631840c601726bef83b74f0f
+  git_url: https://github.com/sandialabs/tracktable-data
+  git_rev: v1.7.2
 build:
   noarch: python
-  number: 3
+  number: 4
   script: "{{ PYTHON }} -m pip install . -vv"
 
 


### PR DESCRIPTION
The tarball created by Github for the tracktable-data release contains pointers to the files in Git LFS rather than the files themselves.

By asking conda-build to check out a new copy of the repository, we should get the full-fat files as we expect.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
