### PR TITLE
Bump build number, minimum Python version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,18 +13,18 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . -vv"
 
 
 requirements:
   host:
-    - python >=3.5
+    - python >=3.9
     - pip
     - python-build
     - setuptools
   run:
-    - python >=3.5
+    - python >=3.9
 
 test:
   imports:


### PR DESCRIPTION
Minimum Python version is now 3.9 since 3.5 is several years out of date.

Build number is now 1 so I can re-trigger builds and see what's going wrong.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ X] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
